### PR TITLE
Some Changes in DUO APIs

### DIFF
--- a/database/apidocs/apis/v2/customer-identity-api/multi-factor-authentication/mfa-email-login.json
+++ b/database/apidocs/apis/v2/customer-identity-api/multi-factor-authentication/mfa-email-login.json
@@ -10,7 +10,8 @@
     "emailtemplate": "",
     "EmailTemplate2FA":"",
     "fields":"*",
-    "options": ""
+    "options": "",
+    "duoredirecturi":""
   },
   "postparams": {
   "email": "Email of the user",
@@ -96,6 +97,11 @@
 				"name":	"options",
 				"is_required": false,
 				"description": "preventverificationsms (Specifying this value prevents the verification sms from being sent. Only applicable if you have the optional sms verification flow)"
+			},
+      {
+				"name":	"duoredirecturi",
+				"is_required": false,
+				"description": "Duo Redirect Uri where duo will send the response. Required to pass if the Duo MFA is enabled."
 			}
     ],
     "Post Params": [

--- a/database/apidocs/apis/v2/customer-identity-api/multi-factor-authentication/mfa-validate-access-token.json
+++ b/database/apidocs/apis/v2/customer-identity-api/multi-factor-authentication/mfa-validate-access-token.json
@@ -5,7 +5,8 @@
   "method":"GET",
   "getparams":{
   "apikey*":"@apikey@",
-  "isvoiceotp" : ""
+  "isvoiceotp" : "",
+  "duoredirecturi" : ""
 
 },
   "postparams":"",
@@ -23,7 +24,12 @@
         "name": "isvoiceotp",
         "is_required": false,
         "description": "Boolean, pass true if you wish to trigger voice OTP"
-      }
+      },
+      {
+				"name":	"duoredirecturi",
+				"is_required": false,
+				"description": "Duo Redirect Uri where duo will send the response. Required to pass if the Duo MFA is enabled."
+			}
     ],
   "Headers Parameters": [{
               "name": "Authorization",

--- a/database/apidocs/apis/v2/customer-identity-api/step-up-authentication/mfa/step-up-auth-trigger.json
+++ b/database/apidocs/apis/v2/customer-identity-api/step-up-authentication/mfa/step-up-auth-trigger.json
@@ -6,7 +6,8 @@
   "getparams":{
   "apikey*":"@apikey@",
   "smstemplate2fa":"",
-  "isvoiceotp" : ""
+  "isvoiceotp" : "",
+  "duoredirecturi" :""
 },
   "postparams":"",
   "headers":{"content-Type":"application/json","Authorization":"Bearer "},
@@ -28,7 +29,12 @@
         "name": "isvoiceotp",
         "is_required": false,
         "description": "Boolean, pass true if you wish to trigger voice OTP"
-      }  
+      },
+      {
+				"name":	"duoredirecturi",
+				"is_required": false,
+				"description": "Duo Redirect Uri where duo will send the response. Required to pass if the Duo MFA is enabled."
+			}  
     ],
   "Headers Parameters": [{
               "name": "Authorization",


### PR DESCRIPTION
The query param `duoRedirectUri` is made required now in case of Duo Authenticator is enabled.